### PR TITLE
Version update checks and centralized quest sharing

### DIFF
--- a/spec/game-env.lua
+++ b/spec/game-env.lua
@@ -142,4 +142,11 @@ function game:AddPlayerEquipment(addon, item)
   mocks[#mocks+1] = addon.G.IsEquippedItem
 end
 
+function game:SetPlayerLevel(addon, level)
+  assert(type(level) == "number", "SetPlayerLevel must receive a number")
+
+  mock:GetFunctionMock(addon.G.UnitLevel):SetReturnsWhen(unitIdIsPlayer, level)
+  mocks[#mocks+1] = addon.G.UnitLevel
+end
+
 return game

--- a/spec/test-config.lua
+++ b/spec/test-config.lua
@@ -4,11 +4,13 @@ return {
   ENABLE_GUI = false,
   ENABLE_SELF_MESSAGING = true,
   ENABLE_TRANSACTION_LOGS = false,
+  ENABLE_UPDATE_NOTIFICATIONS = true,
   FEATURE_PET_KILLS = true,
   GLOBAL_LOG_FILTER = "fatal",
   PLAYER_LOCATION_INTERVAL = 1.0,
   PLAYER_LOCATION_TTL = 0,
   START_MENU = "",
+  VERSION_INFO_TTL = 1,
 
   Logging = {},
   FrameData = {},

--- a/spec/test/msg/ShareQuest_spec.lua
+++ b/spec/test/msg/ShareQuest_spec.lua
@@ -1,0 +1,210 @@
+local addon = require("spec/addon-builder"):Build()
+local events = require("spec/events")
+local game = require("spec/game-env")
+
+local goodScript = [[
+  quest:
+    name: Shared Quest
+    description: I sure hope these tests pass!
+  objectives:
+    - kill 5 Chicken
+    - talk-to 3 "Stormwind Guard"
+    - use-emote dance 2 Cow
+]]
+
+local goodScriptWithRequirements = goodScript..[[
+  required:
+    level: 5]]
+
+describe("ShareQuest", function()
+  local QuestLog, QuestStatus = addon.QuestLog, addon.QuestStatus
+  local QuestArchive = addon.QuestArchive
+  local QuestCatalog, QuestCatalogStatus = addon.QuestCatalog, addon.QuestCatalogStatus
+
+  local eventSpy, questToShare
+
+  local function assertResponded(event)
+    local options = eventSpy:GetPublishPayload(event)
+    assert.equals("WHISPER", options.distribution)
+    assert.equals("*yourself*", options.target)
+  end
+
+  setup(function()
+    addon:Init()
+    eventSpy = events:SpyOnEvents(addon.MessageEvents)
+  end)
+  before_each(function()
+    addon:Advance()
+    eventSpy:Reset()
+    game:ResetEnv(addon)
+    questToShare = addon.QuestScriptCompiler:Compile(goodScript)
+  end)
+  describe("when a quest is shared", function()
+    it("then quest status is cleared on publish", function()
+      questToShare.status = addon.QuestStatus.Active
+      addon:ShareQuest(questToShare)
+      local _, sharedQuest = eventSpy:GetPublishPayload("QuestInvite")
+      assert.is_nil(sharedQuest.status)
+    end)
+    it("then quest progress is cleared on publish", function()
+      questToShare.objectives[1].progress = 1
+      addon:ShareQuest(questToShare)
+      local _, sharedQuest = eventSpy:GetPublishPayload("QuestInvite")
+      assert.equals(0, sharedQuest.objectives[1].progress)
+    end)
+    it("then invalid quests are rejected", function()
+      questToShare.name = nil
+      assert.has_error(function() addon:ShareQuest(questToShare) end)
+    end)
+  end)
+  describe("when a shared quest is received", function()
+    local sharedQuest
+    before_each(function()
+      addon:ShareQuest(questToShare)
+      sharedQuest = questToShare
+    end)
+    after_each(function()
+      QuestCatalog:DeleteAll()
+      QuestLog:DeleteAll()
+      QuestArchive:DeleteAll()
+      addon:Advance()
+    end)
+    it("then the shared quest is saved to the QuestCatalog", function()
+      addon:Advance()
+      local catalogItem = QuestCatalog:FindByID(sharedQuest.questId)
+      assert.is_not_nil(catalogItem)
+      assert.same(sharedQuest, catalogItem.quest)
+    end)
+    describe("and the quest is already in the Catalog", function()
+      local catalogItem
+      before_each(function()
+        catalogItem = QuestCatalog:NewCatalogItem(addon:CopyTable(sharedQuest))
+        catalogItem.quest.name = catalogItem.quest.name.." (Catalog)"
+        QuestCatalog:SaveWithStatus(catalogItem, QuestCatalogStatus.Invited)
+      end)
+      it("then newer shared quest versions are saved to the Catalog", function()
+        catalogItem.quest.metadata.compileDate = catalogItem.quest.metadata.compileDate + 1
+        QuestCatalog:Save(catalogItem)
+
+        addon:Advance()
+        local updatedCatalogItem = QuestCatalog:FindByID(sharedQuest.questId)
+        assert.equals(catalogItem.quest.name, updatedCatalogItem.quest.name)
+      end)
+      it("then older shared quest versions are not saved to the Catalog", function()
+        catalogItem.quest.metadata.compileDate = catalogItem.quest.metadata.compileDate - 1
+        QuestCatalog:Save(catalogItem)
+
+        addon:Advance()
+        local updatedCatalogItem = QuestCatalog:FindByID(sharedQuest.questId)
+        assert.same(sharedQuest, updatedCatalogItem.quest)
+      end)
+      it("then shared quests of the same version are not saved to the Catalog", function()
+        addon:Advance()
+        local updatedCatalogItem = QuestCatalog:FindByID(sharedQuest.questId)
+        assert.same(catalogItem.quest, updatedCatalogItem.quest)
+        eventSpy:AssertNotPublished("QuestInviteDuplicate") -- Just gonna slip this check in here
+      end)
+    end)
+    describe("and the quest is already in the QuestLog", function()
+      local questLogQuest, catalogItem
+      before_each(function()
+        catalogItem = QuestCatalog:NewCatalogItem(addon:CopyTable(questToShare))
+        catalogItem.quest.name = catalogItem.quest.name.." (Catalog)"
+        QuestCatalog:SaveWithStatus(catalogItem, QuestCatalogStatus.Accepted)
+
+        questLogQuest = addon:CopyTable(catalogItem.quest)
+        QuestLog:SaveWithStatus(questLogQuest, QuestStatus.Active)
+      end)
+      it("then the sender is notified of 'duplicate' quests", function()
+        -- Setup: Active is already considered a duplicate status
+
+        addon:Advance()
+        assertResponded("QuestInviteDuplicate")
+      end)
+      it("then the sender is not notified of 'non-duplicate' quests", function()
+        QuestLog:SaveWithStatus(questLogQuest, QuestStatus.Abandoned)
+
+        addon:Advance()
+        eventSpy:AssertNotPublished("QuestInviteDuplicate")
+      end)
+      it("then older catalog versions will still be updated", function()
+        catalogItem.quest.metadata.compileDate = catalogItem.quest.metadata.compileDate - 10
+        QuestCatalog:Save(catalogItem)
+
+        addon:Advance()
+        local updatedCatalogQuest = QuestCatalog:FindByID(sharedQuest.questId)
+        assert.same(sharedQuest, updatedCatalogQuest.quest)
+        assert.not_same(catalogItem.quest, updatedCatalogQuest.quest)
+      end)
+    end)
+    describe("and the quest is already in the QuestArchive", function()
+      local archiveQuest, catalogItem
+      before_each(function()
+        catalogItem = QuestCatalog:NewCatalogItem(addon:CopyTable(questToShare))
+        catalogItem.quest.name = catalogItem.quest.name.." (Catalog)"
+        QuestCatalog:SaveWithStatus(catalogItem, QuestCatalogStatus.Accepted)
+
+        archiveQuest = addon:CopyTable(catalogItem.quest)
+        archiveQuest.status = QuestStatus.Completed
+        QuestArchive:Save(archiveQuest)
+      end)
+      it("then the sender is notified of 'duplicate' quests", function()
+        -- Setup: Completed is already considered a duplicate status
+
+        addon:Advance()
+        assertResponded("QuestInviteDuplicate")
+      end)
+      it("then the sender is not notified of 'non-duplicate' quests", function()
+        archiveQuest.status = QuestStatus.Failed
+        QuestArchive:Save(archiveQuest)
+
+        addon:Advance()
+        eventSpy:AssertNotPublished("QuestInviteDuplicate")
+      end)
+    end)
+  end)
+  describe("when a shared quest is received requirements", function()
+    local sharedQuest
+    before_each(function()
+      sharedQuest = addon.QuestScriptCompiler:Compile(goodScriptWithRequirements)
+      addon:ShareQuest(sharedQuest)
+    end)
+    describe("and the player meets the requirements", function()
+      before_each(function()
+        game:SetPlayerLevel(addon, 60)
+      end)
+      it("then the quest is saved to the catalog", function()
+        addon:Advance()
+        local catalogItem = QuestCatalog:FindByID(sharedQuest.questId)
+        assert.is_not_nil(catalogItem)
+        assert.same(sharedQuest, catalogItem.quest)
+      end)
+    end)
+    describe("and the player does not meet the requirements", function()
+      before_each(function()
+        game:SetPlayerLevel(addon, 1)
+      end)
+      it("then the quest is still saved to the Catalog", function()
+        addon:Advance()
+        local catalogItem = QuestCatalog:FindByID(sharedQuest.questId)
+        assert.is_not_nil(catalogItem)
+        assert.same(sharedQuest, catalogItem.quest)
+      end)
+      it("then the sender is notified", function()
+        addon:Advance()
+        assertResponded("QuestInviteRequirements")
+      end)
+    end)
+  end)
+  describe("when a shared catalog item is received (legacy behavior)", function()
+    it("then the quest is declined", function()
+      -- Previously, catalog items were shared instead of just quests
+      -- If the handler sees something like this, just reject it
+      local catalogItem = addon.QuestCatalog:NewCatalogItem(questToShare)
+      addon.MessageEvents:Publish("QuestInvite", nil, catalogItem)
+
+      addon:Advance()
+      assertResponded("QuestInviteDeclined")
+    end)
+  end)
+end)

--- a/spec/test/msg/ShareQuest_spec.lua
+++ b/spec/test/msg/ShareQuest_spec.lua
@@ -25,7 +25,7 @@ describe("ShareQuest", function()
 
   local function assertResponded(event)
     local options = eventSpy:GetPublishPayload(event)
-    assert.equals("WHISPER", options.distribution)
+    assert.equals(addon.MessageDistribution.Whisper, options.distribution)
     assert.equals("*yourself*", options.target)
   end
 

--- a/spec/test/msg/VersionCheck_spec.lua
+++ b/spec/test/msg/VersionCheck_spec.lua
@@ -1,0 +1,78 @@
+local builder = require("spec/addon-builder")
+local events = require("spec/events")
+
+describe("VersionCheck", function()
+  describe("when the addon is loaded", function()
+    local tempAddon, tempEventSpy
+    before_each(function()
+      tempAddon = builder:Build()
+      tempEventSpy = events:SpyOnEvents(tempAddon.MessageEvents)
+    end)
+    it("can send out a version request", function()
+      tempAddon:Init()
+      tempEventSpy:AssertPublished("AddonVersionRequest")
+    end)
+  end)
+  describe("when a version request is received", function()
+    local addon, eventSpy
+    local branch = "unit-test"
+
+    local function publish(v, b)
+      addon.MessageEvents:Publish("AddonVersionRequest", nil, v, b)
+    end
+
+    before_each(function()
+      addon = builder:Build()
+      addon:Init()
+      addon:Advance()
+      eventSpy = events:SpyOnEvents(addon.MessageEvents)
+    end)
+    it("newer versions are cached", function()
+      publish(addon.VERSION + 1, branch)
+      addon:Advance()
+
+      local kvi = addon.SaveData:LoadTable("KnownVersionInfo", true)
+      assert.equals(addon.VERSION + 1, kvi.version)
+      assert.equals(branch, kvi.branch)
+    end)
+    it("same version is not cached", function()
+      publish(addon.VERSION, branch)
+      addon:Advance()
+
+      local kvi = addon.SaveData:LoadTable("KnownVersionInfo", true)
+      assert.equals(addon.VERSION, kvi.version)
+      assert.equals(addon.BRANCH, kvi.branch)
+    end)
+    it("older version is not cached", function()
+      publish(addon.VERSION - 1, branch)
+      addon:Advance()
+
+      local kvi = addon.SaveData:LoadTable("KnownVersionInfo", true)
+      assert.equals(addon.VERSION, kvi.version)
+      assert.equals(addon.BRANCH, kvi.branch)
+    end)
+    it("a version response is returned", function()
+      publish(addon.VERSION, branch)
+      addon:Advance()
+
+      eventSpy:AssertPublished("AddonVersionResponse")
+    end)
+  end)
+  describe("when a version response is received", function()
+    local addon, eventSpy
+
+    before_each(function()
+      addon = builder:Build()
+      addon:Init()
+      addon:Advance()
+      eventSpy = events:SpyOnEvents(addon.MessageEvents)
+    end)
+    it("a version response is not published", function()
+      addon.MessageEvents:Publish("AddonVersionResponse", nil, addon.VERSION, addon.BRANCH)
+      eventSpy:Reset() -- Don't count ^ this response in the spy
+      addon:Advance()
+
+      eventSpy:AssertNotPublished("AddonVersionResponse")
+    end)
+  end)
+end)

--- a/src/PmqConfig.lua
+++ b/src/PmqConfig.lua
@@ -13,6 +13,9 @@ addon.defaultSettings = {
   --- Enable this for detailed logs on Repository transactions.
   --- Disabled by default because it can be quite verbose.
   ENABLE_TRANSACTION_LOGS = false,
+  --- Enable version update notifications whenever a newer version
+  --- of the addon is detected.
+  ENABLE_UPDATE_NOTIFICATIONS = true,
   --- Feature flag: Count player pet kills towards kill objectives.
   FEATURE_PET_KILLS = true,
   --- All logs below this level will be hidden across all Loggers.
@@ -26,6 +29,9 @@ addon.defaultSettings = {
   --- Show this MainMenu screen immediately when the addon loads.
   --- Set to an empty string to not show any menu on startup.
   START_MENU = "",
+  --- The amount of time in seconds that "known version" info should be cached
+  --- for the purpose of notifying the player of version updates.
+  VERSION_INFO_TTL = 3 * 86400, -- 3 days
 
   Logging = {},
   FrameData = {},

--- a/src/data/QuestArchive.lua
+++ b/src/data/QuestArchive.lua
@@ -1,5 +1,4 @@
 local _, addon = ...
-local GetUnitName = addon.G.GetUnitName
 
 --[[
   Archived quest model:
@@ -11,23 +10,3 @@ addon.QuestArchive:SetSaveDataSource("QuestArchive")
 addon.QuestArchive:EnableWrite(true)
 addon.QuestArchive:EnableCompression(true)
 addon.QuestArchive:EnableTimestamps(true)
-
--- Copy/pasted from QuestLog
-function addon.QuestArchive:ShareQuest(questId)
-  local catalogItem = addon.QuestCatalog:FindByID(questId)
-  if not catalogItem then
-    -- If the quest is not in the player's catalog for some reason
-    -- create a temporary catalog item for the message.
-    -- This could happen when trying to share a demo quest.
-    local quest = self:FindByID(questId)
-    catalogItem = addon.QuestCatalog:NewCatalogItem(quest)
-    if quest.demoId then
-      catalogItem.metadata.demo = true
-      catalogItem.metadata.demoId = quest.demoId
-    end
-  end
-
-  catalogItem.metadata.sender = GetUnitName("player", true)
-  addon.MessageEvents:Publish("QuestInvite", nil, catalogItem)
-  addon.Logger:Warn("Sharing quest %s...", catalogItem.quest.name)
-end

--- a/src/data/QuestCatalog.lua
+++ b/src/data/QuestCatalog.lua
@@ -36,7 +36,7 @@ local QuestCatalogSource = {
   Draft = "Draft",
   Shared = "Shared",
 }
-addon.QuestCatlogSource = QuestCatalogSource
+addon.QuestCatalogSource = QuestCatalogSource
 
 function addon.QuestCatalog:NewCatalogItem(quest)
   assert(quest and quest.questId, "NewCatalogItem failed: a quest must be provided")

--- a/src/data/QuestDrafts.lua
+++ b/src/data/QuestDrafts.lua
@@ -39,7 +39,7 @@ function addon.QuestDrafts:NewDraft()
   return draft
 end
 
-function addon.QuestDrafts:CompileDraft(draftId)
+function addon.QuestDrafts:TryCompileDraft(draftId)
   if not draftId then
     return false, "draftId is required"
   end
@@ -59,47 +59,10 @@ function addon.QuestDrafts:CompileDraft(draftId)
   return true, quest
 end
 
-function addon.QuestDrafts:CatalogDraft(draftId)
-  local ok, quest = self:CompileDraft(draftId)
-  if not ok then
-    addon.Logger:Error("Failed to catalog draft: %s", quest)
-    return
-  end
-
-  local catalogItem = addon.QuestCatalog:FindByID(quest.questId)
-  if not catalogItem then
-    addon.Logger:Debug("Catalog item does not exist for draft. Creating it now...")
-    local draft = self:FindByID(draftId)
-    catalogItem = addon.QuestCatalog:NewCatalogItem(quest)
-    catalogItem.metadata = {
-      author = GetUnitName("player", true),
-      version = draft.version,
-      demoId = draft.parameters.demoId,
-      draftId = draftId,
-      draftStatus = draft.status,
-      created = draft.cd,
-      -- versionCreated = nil,
-      -- published = nil,
-    }
-    addon.QuestCatalog:Save(catalogItem)
-  end
-
-  return catalogItem
-end
-
-function addon.QuestDrafts:ShareDraft(draftId)
-  local catalogItem = self:CatalogDraft(draftId)
-  if not catalogItem then return end
-
-  catalogItem.metadata.sender = GetUnitName("player", true)
-  addon.MessageEvents:Publish("QuestInvite", nil, catalogItem)
-  addon.Logger:Warn("Sharing quest %s...", catalogItem.quest.name)
-end
-
 function addon.QuestDrafts:StartDraft(draftId)
-  local ok, quest = self:CompileDraft(draftId)
+  local ok, quest = self:TryCompileDraft(draftId)
   if not ok then
-    addon.Logger:Error("Failed to start draft: %s", quest)
+    addon.Logger:Warn("Failed to start draft: %s", quest)
     return
   end
   addon:ShowQuestInfoFrame(true, quest)

--- a/src/data/QuestLog.lua
+++ b/src/data/QuestLog.lua
@@ -58,25 +58,6 @@ function QuestLog:Validate(quest)
   addon:ValidateQuestStatusChange(quest)
 end
 
-function QuestLog:ShareQuest(questId)
-  local catalogItem = addon.QuestCatalog:FindByID(questId)
-  if not catalogItem then
-    -- If the quest is not in the player's catalog for some reason
-    -- create a temporary catalog item for the message.
-    -- This could happen when trying to share a demo quest.
-    local quest = self:FindByID(questId)
-    catalogItem = addon.QuestCatalog:NewCatalogItem(quest)
-    if quest.demoId then
-      catalogItem.metadata.demo = true
-      catalogItem.metadata.demoId = quest.demoId
-    end
-  end
-
-  catalogItem.metadata.sender = GetUnitName("player", true)
-  addon.MessageEvents:Publish("QuestInvite", nil, catalogItem)
-  addon.Logger:Warn("Sharing quest %s...", catalogItem.quest.name)
-end
-
 -- Need to listen for objective changes and reflect those changes in the quest log
 
 addon.AppEvents:Subscribe("ObjectiveUpdated", function(obj)

--- a/src/events/MessageEvents.lua
+++ b/src/events/MessageEvents.lua
@@ -3,11 +3,31 @@ local Ace, unpack = addon.Ace, addon.G.unpack
 local GetUnitName = addon.G.GetUnitName
 local encoder = addon.LibCompress:GetAddonEncodeTable()
 
+--- Values defined here: https://wow.gamepedia.com/API_C_ChatInfo.SendAddonMessage
+addon.MessageDistribution = {
+  Party = "PARTY",
+  Raid = "RAID",
+  Instance = "INSTANCE_CHAT",
+  Guild = "GUILD",
+  Officer = "OFFICER",
+  Whisper = "WHISPER",
+  -- Channel = "CHANNEL", -- Not supported in Classic
+  Say = "SAY", -- Only supported in Classic
+  Yell = "YELL", -- Only supported in Classic
+}
+
+--- Values defined here: https://wow.gamepedia.com/ChatThrottleLib
+addon.MessagePriority = {
+  Normal = "NORMAL",
+  Bulk = "BULK",
+  Alert = "ALERT",
+}
+
 local PMQ_MESSAGE_PREFIX = "PMQ"
 local defaultDetails = {
-  distribution = "PARTY", -- see: https://wow.gamepedia.com/API_C_ChatInfo.SendAddonMessage
+  distribution = addon.MessageDistribution.Party,
   target = nil, -- player name, required only for "WHISPER"
-  priority = "NORMAL" -- also allowed: "BULK", "ALERT"
+  priority = addon.MessagePriority.Normal,
 }
 local useInternalMessaging
 local internalPublish

--- a/src/gui/QuestInfoFrame.lua
+++ b/src/gui/QuestInfoFrame.lua
@@ -486,6 +486,8 @@ end
 local questInfoFrame
 
 function addon:ShowQuestInfoFrame(flag, quest, sender, modeName)
+  if not addon.Config:GetValue("ENABLE_GUI") then return end
+
   if flag == nil then flag = true end
   if not questInfoFrame then
     questInfoFrame = buildQuestInfoFrame()

--- a/src/gui/QuestInfoFrame.lua
+++ b/src/gui/QuestInfoFrame.lua
@@ -117,7 +117,7 @@ local buttons = {
     text = "Share Quest",
     width = 122, -- todo: lookup actual width
     action = function(quest)
-      QuestLog:ShareQuest(quest.questId)
+      addon:ShareQuest(quest)
     end
   },
   ["Retry"] = {

--- a/src/gui/QuestInfoFrame.lua
+++ b/src/gui/QuestInfoFrame.lua
@@ -2,6 +2,7 @@ local _, addon = ...
 local CreateFrame = addon.G.CreateFrame
 local QuestLog, QuestStatus = addon.QuestLog, addon.QuestStatus
 local QuestCatalog, QuestCatalogStatus = addon.QuestCatalog, addon.QuestCatalogStatus
+local MessageEvents, MessageDistribution = addon.MessageEvents, addon.MessageDistribution
 local StaticPopups = addon.StaticPopups
 local localizer = addon.QuestScriptLocalizer
 
@@ -43,7 +44,7 @@ local function acceptQuest(quest, sender)
     QuestCatalog:SaveWithStatus(quest.questId, QuestCatalogStatus.Accepted)
   end
   if sender then
-    addon.MessageEvents:Publish("QuestInviteAccepted", { distribution = "WHISPER", target = sender }, quest.questId)
+    MessageEvents:Publish("QuestInviteAccepted", { distribution = MessageDistribution.Whisper, target = sender }, quest.questId)
   end
   addon:PlaySound("QuestAccepted")
   addon:ShowQuestInfoFrame(false)
@@ -81,7 +82,7 @@ local buttons = {
     width = 78,
     action = function(quest, sender)
       if sender then
-        addon.MessageEvents:Publish("QuestInviteDeclined", { distribution = "WHISPER", target = sender }, quest.questId)
+        MessageEvents:Publish("QuestInviteDeclined", { distribution = MessageDistribution.Whisper, target = sender }, quest.questId)
         QuestCatalog:SaveWithStatus(quest.questId, QuestCatalogStatus.Declined)
       end
       addon:ShowQuestInfoFrame(false)

--- a/src/gui/menu/QuestArchiveMenu.lua
+++ b/src/gui/menu/QuestArchiveMenu.lua
@@ -42,7 +42,7 @@ local options = {
       anchor = "TOP",
       enabled = "Row",
       handler = function(quest)
-        QuestArchive:ShareQuest(quest.questId)
+        addon:ShareQuest(quest)
       end,
     },
     {

--- a/src/gui/menu/QuestCatalogMenu.lua
+++ b/src/gui/menu/QuestCatalogMenu.lua
@@ -41,7 +41,7 @@ local options = {
       anchor = "TOP",
       enabled = "Row",
       handler = function(catalogItem)
-        QuestCatalog:ShareFromCatalog(catalogItem.questId)
+        addon:ShareQuest(catalogItem.quest)
       end,
     },
     {

--- a/src/gui/menu/QuestDraftListMenu.lua
+++ b/src/gui/menu/QuestDraftListMenu.lua
@@ -61,7 +61,12 @@ local options = {
       anchor = "TOP",
       enabled = "Row",
       handler = function(draft)
-        addon.QuestDrafts:ShareDraft(draft.draftId)
+        local ok, quest = addon.QuestDrafts:TryCompileDraft(draft.draftId)
+        if not ok then
+          addon.Logger:Warn("Your quest contains an error and cannot be shared: %s", quest)
+          return
+        end
+        addon:ShareQuest(quest)
       end,
     },
     {

--- a/src/gui/menu/QuestLogMenu.lua
+++ b/src/gui/menu/QuestLogMenu.lua
@@ -55,7 +55,7 @@ local options = {
       anchor = "TOP",
       enabled = "Row",
       handler = function(quest)
-        QuestLog:ShareQuest(quest.questId)
+        addon:ShareQuest(quest)
       end,
     },
     {

--- a/src/index.xml
+++ b/src/index.xml
@@ -7,5 +7,6 @@
   <Include file="data/index.xml"/>
   <Include file="game/index.xml"/>
   <Include file="qeng/index.xml"/>
+  <Include file="msg/index.xml"/>
   <Include file="gui/index.xml"/>
 </Ui>

--- a/src/msg/ShareQuest.lua
+++ b/src/msg/ShareQuest.lua
@@ -70,6 +70,9 @@ addon:OnBackendStart(function()
   }
 
   MessageEvents:Subscribe("QuestInvite", function(distribution, sender, quest)
+    -- As a bonus, do a version check whenever you receive a quest invite
+    addon:RequestAddonVersion(MessageDistribution.Whisper, sender)
+
     if quest.quest then
       -- The payload is probably a QuestCatalog item, stop handling now
       -- todo: come up with a better method for handling version incompatibilities

--- a/src/msg/ShareQuest.lua
+++ b/src/msg/ShareQuest.lua
@@ -118,7 +118,7 @@ addon:OnBackendStart(function()
       addon.QuestCatalog:Save(catalogItem, QuestCatalogStatus.Invited)
     end
 
-    -- Now that we have catalogged the latest version of the quest, how do we notify the receiving player?
+    -- Now that we have catalogued the latest version of the quest, how do we notify the receiving player?
     local duplicateStatus
 
     -- If the catalog status is "Accepted", then the player has accepted an invite for this quest in the past

--- a/src/msg/ShareQuest.lua
+++ b/src/msg/ShareQuest.lua
@@ -22,7 +22,9 @@ local function getNewerQuest(q1, s1, q2, s2)
     return q2, s2
   end
 
-  if q2.metadata.compileDate > q1.metadata.compileDate and q2.metadata.hash ~= q1.metadata.hash then
+  if q2.metadata.compileDate == nil then
+    return q1, s1
+  elseif q2.metadata.compileDate > q1.metadata.compileDate and q2.metadata.hash ~= q1.metadata.hash then
     -- q2 must be more recently compiled AND have a different hash in order to overtake q1
     return q2, s2
   end

--- a/src/msg/ShareQuest.lua
+++ b/src/msg/ShareQuest.lua
@@ -22,7 +22,8 @@ local function getNewerQuest(q1, s1, q2, s2)
     return q2, s2
   end
 
-  if q2.metadata.compileDate > q1.metadata.compileDate then
+  if q2.metadata.compileDate > q1.metadata.compileDate and q2.metadata.hash ~= q1.metadata.hash then
+    -- q2 must be more recently compiled AND have a different hash in order to overtake q1
     return q2, s2
   end
 

--- a/src/msg/ShareQuest.lua
+++ b/src/msg/ShareQuest.lua
@@ -61,7 +61,7 @@ addon:OnBackendStart(function()
       message = "%s is already on that quest."
     },
     [QuestStatus.Finished] = {
-      message = "%s has finished that quest, but has not yet completed it.",
+      message = "%s has finished that quest, but has not turned it in.",
     },
     [QuestStatus.Completed] = {
       message = "%s has completed that quest."

--- a/src/msg/ShareQuest.lua
+++ b/src/msg/ShareQuest.lua
@@ -1,0 +1,175 @@
+local _, addon = ...
+local QuestCatalogSource, QuestCatalogStatus, QuestStatus = addon.QuestCatalogSource, addon.QuestCatalogStatus, addon.QuestStatus
+local UnitFullName = addon.G.UnitFullName
+
+local function cleanQuestForSharing(quest)
+  quest.status = nil
+
+  for _, obj in pairs(quest.objectives) do
+    obj.progress = 0
+  end
+end
+
+local function getNewerQuest(q1, s1, q2, s2)
+  if (not q1 or not q1.metadata) and (not q2 or not q2.metadata) then
+    error("Cannot determine newer question version - neither quest contains version information")
+  elseif (q1 and q1.metadata) and (not q2 or not q2.metadata) then
+    -- Quest 1 can be version-checked, but quest 2 cannot
+    return q1, s1
+  elseif (q2 and q2.metadata) and (not q1 or not q1.metadata) then
+    -- Quest 2 can be version-checked, but quest 1 cannot
+    return q2, s2
+  end
+
+  if q2.metadata.compileDate > q1.metadata.compileDate then
+    return q2, s2
+  end
+
+  return q1, s1
+end
+
+local function findNewestQuestVersion(quest)
+  local questId, source = quest.questId, "Shared"
+
+  quest, source = getNewerQuest(quest, source, addon.QuestCatalog:FindByID(questId), "QuestCatalog")
+  quest, source = getNewerQuest(quest, source, addon.QuestLog:FindByID(questId), "QuestLog")
+  quest, source = getNewerQuest(quest, source, addon.QuestArchive:FindByID(questId), "QuestArchive")
+
+  addon.Logger:Trace("Newest quest version resolved: %s (%s)", source, tostring(quest.metadata.compileDate))
+  return quest, source
+end
+
+function addon:ShareQuest(quest)
+  assert(type(quest) == "table", "Failed to ShareQuest: a quest must be provided")
+
+  -- Make a copy for sharing, and clean the current player's status/progress from it
+  quest = addon:CopyTable(quest)
+  cleanQuestForSharing(quest)
+  addon.QuestEngine:Validate(quest) -- Sanity check, don't want to send players broken quests
+
+  addon.MessageEvents:Publish("QuestInvite", nil, quest) -- Currently only shares with default channel ("PARTY")
+  addon.Logger:Warn("Sharing quest %s...", quest.name)
+end
+
+addon:OnBackendStart(function()
+  local considerDuplicate = {
+    [QuestStatus.Active] = {
+      message = "%s is already on that quest."
+    },
+    [QuestStatus.Finished] = {
+      message = "%s has finished that quest, but has not yet completed it.",
+    },
+    [QuestStatus.Completed] = {
+      message = "%s has completed that quest."
+    }
+  }
+
+  addon.MessageEvents:Subscribe("QuestInvite", function(distribution, sender, quest)
+    if quest.quest then
+      -- The payload is probably a QuestCatalog item, stop handling now
+      -- todo: come up with a better method for handling version incompatibilities
+      addon.Logger:Warn("%s tried to share a quest with you, but their addon is out-of-date.", sender)
+      addon.Logger:Warn("Please ask them to update PMQ to %s or later and restart their game.", addon:GetVersionText())
+      addon.MessageEvents:Publish("QuestInviteDeclined", { distribution = "WHISPER", target = sender })
+      return
+    end
+
+    -- Need to determine the most recent known version of this quest from all possible sources
+    local source
+    quest, source = findNewestQuestVersion(quest)
+    cleanQuestForSharing(quest) -- Failsafe: erase any previous progress from quest, in case it got sent over
+    addon.QuestEngine:Validate(quest) -- Sanity check: ensure quest is playable before proceeding
+
+    -- Once we've found the most recent one, perform any migrations (if necessary) to bring the quest up to the current addon version
+    local ok, err = addon:MigrateQuest(quest)
+    if not ok then
+      addon.Logger:Warn("%s tried to share a quest with you, but there was a migration error: %s", sender, err)
+      addon.Logger:Warn("Please ask them to update PMQ to %s or later and restart their game.", addon:GetVersionText())
+      addon.MessageEvents:Publish("QuestInviteDeclined", { distribution = "WHISPER", target = sender })
+      return
+    end
+
+    -- Get or create the catalog entry for this quest
+    local doSaveCatalog, catalogQuestVersionUpdated = false, false
+    local catalogItem = addon.QuestCatalog:FindByID(quest.questId)
+    if not catalogItem then
+      catalogItem = addon.QuestCatalog:NewCatalogItem(quest)
+      doSaveCatalog = true
+    else
+      -- If necessary, update the catalog to have the now-latest known version of the quest
+      quest, source = getNewerQuest(catalogItem.quest, "QuestCatalog", quest, source)
+      if source ~= "QuestCatalog" then
+        catalogItem.quest = quest
+        doSaveCatalog = true
+        catalogQuestVersionUpdated = true
+      end
+    end
+
+    -- If there were any updates made to the catalog entry (or a new entry was created), save it now
+    -- Update the "from" information to be whoever sent this QuestInvite
+    if doSaveCatalog then
+      -- Since there is no cross-realm in classic, we can assume the sender's realm is the same as the player's realm
+      local _, realm = UnitFullName("player")
+      catalogItem.from = {
+        source = QuestCatalogSource.Shared,
+        name = sender,
+        realm = realm,
+      }
+      addon.QuestCatalog:Save(catalogItem, QuestCatalogStatus.Invited)
+    end
+
+    -- Now that we have catalogged the latest version of the quest, how do we notify the receiving player?
+    local duplicateStatus
+
+    -- If the catalog status is "Accepted", then the player has accepted an invite for this quest in the past
+    -- and no changes were made (otherwise it would have reverted back to "Invited")
+    if catalogItem.status == "Accepted" then
+      duplicateStatus = catalogItem.quest.status
+    else
+      local questLogQuest = addon.QuestLog:FindByID(quest.questId)
+      if questLogQuest and considerDuplicate[questLogQuest.status] then
+        duplicateStatus = questLogQuest.status
+      else
+        local archiveQuest = addon.QuestArchive:FindByID(quest.questId)
+        if archiveQuest and considerDuplicate[archiveQuest.status] then
+          duplicateStatus = archiveQuest.status
+        end
+      end
+    end
+
+    if duplicateStatus then
+      addon.MessageEvents:Publish("QuestInviteDuplicate", { distribution = "WHISPER", target = sender }, quest.questId, duplicateStatus)
+      if catalogQuestVersionUpdated then
+        addon.Logger:Warn("%s shared a new version of a quest: %s", sender, quest.name)
+        addon.Logger:Warn("Start this quest from your Catalog to play this new version.")
+      end
+      return
+    end
+
+    addon.Logger:Warn("%s has invited you to a quest: %s", sender, catalogItem.quest.name)
+
+    -- Finally, check the quest's requirements to ensure the player can start it
+    local meetsRequirements = addon.QuestEngine:EvaluateRequirements(quest)
+    if meetsRequirements then
+      addon:ShowQuestInfoFrame(true, catalogItem.quest, sender)
+    else
+      addon.Logger:Warn("You do not meet the requirements, but it has been saved to your Catalog.")
+      addon.MessageEvents:Publish("QuestInviteRequirements", { distribution = "WHISPER", target = sender }, quest.questId)
+    end
+  end)
+
+  addon.MessageEvents:Subscribe("QuestInviteAccepted", function(distribution, sender, questId)
+    addon.Logger:Warn("%s has accepted your quest.", sender)
+  end)
+  addon.MessageEvents:Subscribe("QuestInviteDeclined", function(distribution, sender, questId)
+    addon.Logger:Warn("%s has declined your quest.", sender)
+  end)
+  addon.MessageEvents:Subscribe("QuestInviteDuplicate", function(distribution, sender, questId, status)
+    if status and considerDuplicate[status] then
+      addon.Logger:Warn(considerDuplicate[status].message, sender)
+    end
+  end)
+  addon.MessageEvents:Subscribe("QuestInviteRequirements", function(distribution, sender, questId)
+    addon.Logger:Warn("%s does not meet the requirements for that quest.", sender)
+  end)
+end)

--- a/src/msg/VersionCheck.lua
+++ b/src/msg/VersionCheck.lua
@@ -1,0 +1,74 @@
+local _, addon = ...
+local MessageEvents, MessageDistribution, MessagePriority = addon.MessageEvents, addon.MessageDistribution, addon.MessagePriority
+local time = addon.G.time
+
+--- Only notify player of version updates once per session
+local hasNotifiedVersion
+local updateNotificationsEnabled
+local knownVersionInfo
+
+local function saveVersionInfo(version, branch)
+  version = version or addon.VERSION
+  branch = branch or addon.BRANCH
+
+  knownVersionInfo.version = version
+  knownVersionInfo.branch = branch
+  knownVersionInfo.date = time()
+  addon.SaveData:Save("KnownVersionInfo", knownVersionInfo, true)
+end
+
+local function loadVersionInfo()
+  knownVersionInfo = addon.SaveData:LoadTable("KnownVersionInfo", true)
+
+  if not knownVersionInfo.version then
+    -- Nothing is saved, save current addon version as highest known version
+    saveVersionInfo()
+    return
+  end
+
+  local ttl = addon.Config:GetValue("VERSION_INFO_TTL")
+  local expires = knownVersionInfo.date + ttl
+  if time() > expires then
+    -- Cached version info is expired, overwrite w/ current version info
+    saveVersionInfo()
+  end
+end
+
+local function notifyVersion(version, branch)
+  if version > knownVersionInfo.version then
+    saveVersionInfo(version, branch)
+    if updateNotificationsEnabled and not hasNotifiedVersion then
+      local newVersionText = addon:GetVersionText(version, branch)
+      addon.Logger:Warn("A new version of PMQ is available (%s).", newVersionText)
+      hasNotifiedVersion = true
+    end
+  end
+end
+
+local function tellVersion(event, distro, target)
+  MessageEvents:Publish(event,
+    { distribution = distro, target = target, priority = MessagePriority.Bulk },
+    addon.VERSION, addon.BRANCH)
+end
+
+function addon:BroadcastVersion()
+  tellVersion("AddonVersionRequest", MessageDistribution.Yell)
+  tellVersion("AddonVersionRequest", MessageDistribution.Guild)
+end
+
+addon:OnBackendStart(function()
+  loadVersionInfo()
+  updateNotificationsEnabled = addon.Config:GetValue("ENABLE_UPDATE_NOTIFICATIONS")
+
+  MessageEvents:Subscribe("AddonVersionRequest", function(distribution, sender, version, branch)
+    notifyVersion(version, branch)
+    tellVersion("AddonVersionResponse", MessageDistribution.Whisper, sender)
+  end)
+  MessageEvents:Subscribe("AddonVersionResponse", function(distribution, sender, version, branch)
+    notifyVersion(version, branch)
+  end)
+end)
+
+addon:OnAddonReady(function()
+  addon:BroadcastVersion()
+end)

--- a/src/msg/VersionCheck.lua
+++ b/src/msg/VersionCheck.lua
@@ -51,9 +51,13 @@ local function tellVersion(event, distro, target)
     addon.VERSION, addon.BRANCH)
 end
 
-function addon:BroadcastVersion()
+function addon:BroadcastAddonVersion()
   tellVersion("AddonVersionRequest", MessageDistribution.Yell)
   tellVersion("AddonVersionRequest", MessageDistribution.Guild)
+end
+
+function addon:RequestAddonVersion(distro, target)
+  tellVersion("AddonVersionRequest", distro, target)
 end
 
 addon:OnBackendStart(function()
@@ -70,5 +74,5 @@ addon:OnBackendStart(function()
 end)
 
 addon:OnAddonReady(function()
-  addon:BroadcastVersion()
+  addon:BroadcastAddonVersion()
 end)

--- a/src/msg/index.xml
+++ b/src/msg/index.xml
@@ -1,3 +1,4 @@
 <Ui xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
   <Script file="msg/ShareQuest.lua"/>
+  <Script file="msg/VersionCheck.lua"/>
 </Ui>

--- a/src/msg/index.xml
+++ b/src/msg/index.xml
@@ -1,0 +1,3 @@
+<Ui xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
+  <Script file="msg/ShareQuest.lua"/>
+</Ui>

--- a/src/qeng/QuestScriptCompiler.lua
+++ b/src/qeng/QuestScriptCompiler.lua
@@ -23,6 +23,16 @@ local function buildMetadata()
   return metadata
 end
 
+local function signQuestHash(quest)
+  -- Temporarily remove metadata from the quest, as it should not affect the hash
+  local metadata = quest.metadata
+  quest.metadata = nil
+
+  metadata.hash = tostring(addon:GetTableHash(quest))
+
+  quest.metadata = metadata
+end
+
 --[[
   Parses a QuestScript "file" (set of lines) and/or a set of quest parameters
   into a Quest that can be stored in the QuestLog and tracked.
@@ -73,6 +83,9 @@ function addon.QuestScriptCompiler:Compile(script, questParams)
     metadata = addon:MergeTable(metadata, quest.metadata)
   end
   quest.metadata = metadata
+
+  -- Final step: sign the quest with a hash
+  signQuestHash(quest)
 
   -- Verify with the QuestEngine that this quest will be runnable
   addon.QuestEngine:Validate(quest)

--- a/src/util/SaveData.lua
+++ b/src/util/SaveData.lua
@@ -36,52 +36,54 @@ function addon.SaveData:Init()
   addon.AppEvents:Publish("SaveDataLoaded")
 end
 
--- Returns the value of the specified field from SavedVariables
--- If the value is a table, then a copy of the saved table is returned
+--- Returns the value of the specified field from SavedVariables
+--- If the value is a table, then a copy of the saved table is returned
 function addon.SaveData:Load(field, global)
   assert(isSaveDataLoaded, "Failed to Load field"..field..": SaveData not loaded")
   local value = getSaveTable(global)[field]
-  logger:Trace("SaveData field loaded: %s", field)
+  if value ~= nil then
+    logger:Trace("SaveData field loaded: %s", field)
+  end
   return value
 end
 
--- Same as Load, but ensures that the returned value is a table
--- If the value is not a table, then a new empty table is returned
+--- Same as Load, but ensures that the returned value is a table
+--- If the value is not a table, then a new empty table is saved and returned
 function addon.SaveData:LoadTable(field, global)
   local saved = self:Load(field, global)
-  if saved == nil or type(saved) ~= "table" then
+  if type(saved) ~= "table" then
     saved = {}
     self:Save(field, saved, global)
   end
   return saved
 end
 
--- Same as Load, but ensures that the returned value is a string
--- If the value is not a string, then an empty string is returned
+--- Same as Load, but ensures that the returned value is a string
+--- If the value is not a string, then an empty string is saved and returned
 function addon.SaveData:LoadString(field, global)
   local saved = self:Load(field, global)
-  if saved == nil or type(saved) ~= "string" then
+  if type(saved) ~= "string" then
     saved = ""
     self:Save(field, saved, global)
   end
   return saved
 end
 
--- Saves the value to the specified field in SavedVariables
+--- Saves the value to the specified field in SavedVariables
 function addon.SaveData:Save(field, value, global)
   assert(isSaveDataLoaded, "Failed to Save field"..field..": SaveData not loaded")
   getSaveTable(global)[field] = value
   logger:Trace("SaveData field saved: %s", field)
 end
 
--- Saves nil to the specified field in SavedVariables
+--- Saves nil to the specified field in SavedVariables
 function addon.SaveData:Clear(field, global)
   assert(isSaveDataLoaded, "Failed to Clear field "..field..": SaveData not loaded")
   getSaveTable(global)[field] = nil
   logger:Debug("SaveData field cleared: %s", field)
 end
 
--- Resets all SavedVariables
+--- Resets all SavedVariables
 function addon.SaveData:ClearAll(global)
   assert(isSaveDataLoaded, "Failed to ClearAll: SaveData not loaded")
   local t = getSaveTable(global)

--- a/src/util/Strings.lua
+++ b/src/util/Strings.lua
@@ -65,12 +65,16 @@ function addon:Pluralize(num, singular, plural)
   end
 end
 
-function addon:GetVersionText()
-  local major, minor, patch = addon.VERSION / 10000, (addon.VERSION / 100) % 100, addon.VERSION % 100
+function addon:GetVersionText(version, branch)
+  version = version or addon.VERSION
+  branch = branch or addon.BRANCH
+
+  local major, minor, patch = version / 10000, (version / 100) % 100, version % 100
   local text = string.format("v%i.%i.%i", major, minor, patch)
-  if addon.BRANCH then
-    text = text.."-"..addon.BRANCH
+  if branch then
+    text = text.."-"..branch
   end
+
   return text
 end
 


### PR DESCRIPTION
Resolves #103 and #106 

Quest sharing to earlier versions is not strictly block, but since the sharing schema has changed (now a Quest instead of a QuestCatalog item), any QuestInvite payloads that look like a catalog item will be instantly blocked. A better long-term solution is probably needed but... let's see how this goes.